### PR TITLE
Fix missing dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ markdown
 python-multipart
 setuptools
 requests
+sentence-transformers
+faiss-cpu


### PR DESCRIPTION
## Summary
- install FAISS and sentence-transformers

## Testing
- `python -m py_compile api.py build_index.py app.py preprocess.py qa.py savelogin.py scrape_course.py scrape_course_markdown.py scrape_discourse.py scrape_discourse_playwright.py test_api.py`
- `python test_api.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install -r requirements.txt` *(fails: could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68451a8ac62083218e7826443cce8405